### PR TITLE
feat: add professional design system and API configuration

### DIFF
--- a/frontend/mocker_web/lib/config/api_config.dart
+++ b/frontend/mocker_web/lib/config/api_config.dart
@@ -1,0 +1,29 @@
+class ApiConfig {
+  // Base API configuration
+  static const String baseUrl = 'http://localhost:8000';
+  
+  // Authentication endpoints
+  static const String authInitEndpoint = '/auth/init';
+  
+  // User endpoints
+  static const String userEndpoint = '/user';
+  static const String userAvatarEndpoint = '/user/avatar';
+  
+  // Workflow endpoints
+  static const String workflowsEndpoint = '/workflows';
+  static const String workflowStartWithPdfEndpoint = '/workflows/start-with-pdf';
+  static String recommendedQAEndpoint(String workflowId) => '/workflows/$workflowId/recommended-qa';
+  
+  // Interview endpoints
+  static const String interviewsStartEndpoint = '/interviews/start';
+  
+  // Interview feedback endpoints
+  static String interviewFeedbackEndpoint(String sessionId) => '/interviews/$sessionId/feedback';
+  static String workflowInterviewsEndpoint(String workflowId) => '/workflows/$workflowId/interviews';
+  
+  // WebSocket endpoints
+  static String getWebSocketUrl(String sessionId, String parameter) {
+    final wsBaseUrl = baseUrl.replaceFirst('http://', 'ws://').replaceFirst('https://', 'wss://');
+    return '$wsBaseUrl/ws/$sessionId?$parameter';
+  }
+} 

--- a/frontend/mocker_web/lib/theme/app_theme.dart
+++ b/frontend/mocker_web/lib/theme/app_theme.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppTheme {
+  // color scheme
+  static const Color primaryBlue = Color(0xFF2563EB);      
+  static const Color lightBlue = Color(0xFFE6F0FF);        
+  static const Color darkGray = Color(0xFF1F2937);        
+  static const Color mediumGray = Color(0xFF6B7280);      
+  static const Color lightGray = Color(0xFFF9FAFB);       
+  static const Color borderGray = Color(0xFFE5E7EB);       
+  static const Color surfaceWhite = Color(0xFFFFFFFF);    
+
+  static ThemeData get lightTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: primaryBlue,
+          brightness: Brightness.light,
+        ),
+        useMaterial3: true,
+        scaffoldBackgroundColor: lightGray,
+        textTheme: GoogleFonts.notoSansTextTheme().apply(
+          bodyColor: darkGray,
+          displayColor: darkGray,
+        ),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: surfaceWhite,
+          foregroundColor: darkGray,
+          elevation: 0,
+        ),
+        cardTheme: const CardThemeData(
+          color: surfaceWhite,
+          elevation: 2,
+          shadowColor: Colors.black12,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(12)),
+          ),
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: primaryBlue,
+            foregroundColor: surfaceWhite,
+            elevation: 2,
+            shadowColor: primaryBlue.withValues(alpha: 0.3),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+        ),
+      );
+} 


### PR DESCRIPTION
## Summary
Implement professional blue-gray design system and API configuration.

## Changes
- Create AppTheme with professional color palette
- Add Material Design components with custom styling
- Configure API endpoints and base URLs
- Set up responsive design tokens

## Checklist
- [/] I've run all relevant tests with `pytest` and they passed
- [x] Code follows the same **import convention** using absolute paths. (e.g. `from backend.data.database import firestore_db`)
- [/] I've updated or added tests as needed
- [x] I've updated `requirements.txt` if I installed new packages
- [x] I've added/updated `README.md` if I made any necessary setup/config changes (env vars, API keys, Tool setup like Firebase, complex test instructions, etc.) 