### PR TITLE
fix: integrate Firebase Analytics and update dependencies

### DIFF
--- a/frontend/mocker_web/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/frontend/mocker_web/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -21,6 +21,11 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin file_picker, com.mr.flutter.plugin.filepicker.FilePickerPlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new io.flutter.plugins.firebase.analytics.FlutterFirebaseAnalyticsPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin firebase_analytics, io.flutter.plugins.firebase.analytics.FlutterFirebaseAnalyticsPlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new io.flutter.plugins.firebase.auth.FlutterFirebaseAuthPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin firebase_auth, io.flutter.plugins.firebase.auth.FlutterFirebaseAuthPlugin", e);

--- a/frontend/mocker_web/lib/main.dart
+++ b/frontend/mocker_web/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'theme/app_theme.dart';
 import 'pages/dashboard_page.dart';
 import 'services/auth_service.dart';
@@ -8,27 +9,28 @@ import 'firebase_options.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
-  
-  runApp(const IntelliviewApp());
+
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  await FirebaseAnalytics.instance.logEvent(name: 'test_event');
+
+  runApp(IntelliviewApp());
 }
 
 class IntelliviewApp extends StatelessWidget {
-  const IntelliviewApp({super.key});
+  final FirebaseAnalytics analytics = FirebaseAnalytics.instance;
+  IntelliviewApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
-      providers: [
-        ChangeNotifierProvider(create: (_) => AuthService()),
-      ],
+      providers: [ChangeNotifierProvider(create: (_) => AuthService())],
       child: MaterialApp(
         title: 'Intelliview interview preparation',
         theme: AppTheme.lightTheme,
         home: const DashboardPage(),
+        navigatorObservers: [
+          FirebaseAnalyticsObserver(analytics: analytics), // screen changes
+        ],
       ),
     );
   }

--- a/frontend/mocker_web/pubspec.lock
+++ b/frontend/mocker_web/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: bb84ee51e527053dd8e25ecc9f97a6abfdc19130fb4d883e4e8585e23e7e6dd8
+      sha256: "948f7d74f41dd6f2d563ea9f4c21d7ea764f8e047d2b24138974c19c24d37eb6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.60"
+    version: "1.3.61"
   args:
     dependency: transitive
     description:
@@ -121,6 +121,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.3.2"
+  firebase_analytics:
+    dependency: "direct main"
+    description:
+      name: firebase_analytics
+      sha256: dde9d6a7b69b07551a77cfb913c81c64804f7602b07541328322c321e73f2a0e
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.1"
+  firebase_analytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_analytics_platform_interface
+      sha256: "4008d82a58edcbedec34a7b39f457eed24181cb9c89782c104828c42e4c859b2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
+  firebase_analytics_web:
+    dependency: transitive
+    description:
+      name: firebase_analytics_web
+      sha256: db2a2e8803f5471a5f89b4abacae95ae27e0644f77526879fb81a2c1abc12b5f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0+1"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -149,10 +173,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "6b343e6f7b72a4f32d7ce8df8c9a28d8f54b4ac20d7c6500f3e8b3969afca457"
+      sha256: "967dae9a65f69377beb9f4ab292ea63ce5befa1ce24682cab1b69ca4b7a46927"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -165,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "5d28b14dd32282fb7ce2b22b897362453755b6b8541d491127dc72b755bb7b16"
+      sha256: f7ee08febc1c4451588ce58ffcf28edaee857e9a196fee88b85deb889990094a
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/frontend/mocker_web/pubspec.yaml
+++ b/frontend/mocker_web/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   http: ^1.5.0
   http_parser: ^4.0.2
   shared_preferences: ^2.3.3
+  firebase_analytics: ^12.0.1
 
 dev_dependencies:
   flutter_test:

--- a/frontend/mocker_web/web/index.html
+++ b/frontend/mocker_web/web/index.html
@@ -36,6 +36,19 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+    <!-- Firebase App (core) -->
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js"></script>
+
+  <!-- gtag -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-R4BK02VM8F"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-R4BK02VM8F');
+  </script>
+
+  <!-- Flutter bootstrap last -->
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
Enable GA4 Analytics(web) and update Hosting build/deploy

- Add `firebase_analytics` to Flutter project
- Initialize Analytics in app startup and add screen tracking.
- Confirm firebase_options.dart carries measurementId for web.
- Tested the GA is working and website has no issue
- Deployed Firebase Hosting serves with updated build/web

## Deployment
```bash
flutter clean
flutter pub get
flutter build web --release
firebase deploy --only hosting
```

## Notes/Questions
- It’s already deployed, so just open the app URL and test it out.
- Haven't finished the ios setup 
    - (iOS): make sure GoogleService-Info.plist is present and pod 'Firebase/Analytics' is included (run pod install in ios/)
- Can safely remove the test log in the future once you all done testing or we can set up different event to track

## Checklist
- [ ] I’ve run all relevant tests with `pytest` and they passed
- [x] Code follows the same **import convention** using absolute paths. (e.g. `from backend.data.database import firestore_db`)
- [x] I’ve updated or added tests as needed
- [x] I’ve updated `requirements.txt` if I installed new packages
- [ ] I’ve added/updated `README.md` if I made any necessary setup/config changes (env vars, API keys, Tool setup like Firebase, complex test instructions, etc.)

## How to Test
1. flutter pub get
2. Web: flutter build web --release
3. Verify GA4 Realtime shows active user:
    - Open preview URL in incognito → DevTools Network and filter "collect" (which shows event requests to GA, ex: https://www.google-analytics.com/g/collect?...tid=G-XXXX) 
    - Check the Request Payload and should showed `en=test_event`
    - Confirm event in GA4 Realtime.
<img width="555" height="776" alt="Screenshot 2025-09-08 at 12 35 20 PM" src="https://github.com/user-attachments/assets/4cbaae7b-3871-4242-bb0b-c52b86f7d36c" />
