### PR TITLE
Feat: Enable Audio Mode with Vosk Speech-to-Text Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ __pycache__/
 credentials/
 .tokens/*.json
 
-
 # leetcode data files
 backend/scripts/leetcode_problems.json
 backend/scripts/cleaned.json
+
+# model path
+models/

--- a/backend/agents/interviewer/README.md
+++ b/backend/agents/interviewer/README.md
@@ -1,0 +1,39 @@
+# Speech-to-Text with Vosk
+We use **Vosk** for speech-to-text conversion in the backend.
+This allows us to transcribe PCM audio (audio/pcm) into text in real-time or batch mode without relying on cloud APIs (no token cost)
+
+## Setup
+1. Install Python dependencies (from `requirements.txt`):
+```bash
+pip install -r requirements.txt
+```
+2. Download the **Vosk model** (not stored in GitHub because it’s large):
+Run the provided script:
+```bash
+bash scripts/download_vosk_model.sh
+```
+This will:
+- Download the English small model (`vosk-model-small-en-us-0.15`)
+- Extract it into the `models/` folder
+- Skip download if it’s already present
+
+## Relevant files for speech to text
+```
+backend/
+├── agents/
+│   └── interviewer/
+│       └── agent.py         # Main agent code handling audio/text messages
+├── utils/
+│   └── speech_to_text.py    # Wrapper for Vosk transcription
+├── scripts/
+│   └── download_vosk_model.sh   # Script to fetch/unzip Vosk model
+├── requirements.txt
+└── ...
+
+```
+
+## Deployment Notes (Google Cloud Run)
+1. Model Handling
+- The model is not stored in GitHub.
+- We fetch it during the Docker build step via scripts/download_vosk_model.sh.
+2. Add Dockerfile snippet

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -121,3 +121,4 @@ setuptools==78.1.0
 sympy==1.13.1
 tiktoken==0.9.0
 wheel==0.44.0
+vosk==0.3.45

--- a/backend/scripts/download_vosk_model.sh
+++ b/backend/scripts/download_vosk_model.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+MODEL_URL="https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip"
+MODEL_DIR="models/vosk-model-small-en-us-0.15"
+
+if [ ! -d "$MODEL_DIR" ]; then
+  echo "Downloading Vosk model..."
+  mkdir -p models
+  curl -L -o models/vosk-model-small-en-us-0.15.zip $MODEL_URL
+  unzip models/vosk-model-small-en-us-0.15.zip -d models
+else
+  echo "Model already exists, skipping download."
+fi

--- a/backend/tools/speech_to_text.py
+++ b/backend/tools/speech_to_text.py
@@ -1,0 +1,34 @@
+import json
+import numpy as np
+from vosk import Model, KaldiRecognizer
+
+# Load Vosk model once (update the path if you put the model elsewhere)
+# Make sure you've unzipped vosk-model-small-en-us-0.15
+vosk_model = Model("models/vosk-model-small-en-us-0.15")
+
+def run_speech_to_text(pcm_bytes: bytes, sample_rate: int = 16000) -> str:
+    """
+    Convert raw PCM16 audio bytes into text using Vosk.
+
+    Args:
+        pcm_bytes (bytes): PCM16 little-endian audio data.
+        sample_rate (int): Sample rate of the audio (default 16kHz).
+
+    Returns:
+        str: Transcribed text or fallback if transcription fails.
+    """
+    try:
+        # Convert raw PCM bytes → numpy int16 array
+        audio_array = np.frombuffer(pcm_bytes, dtype=np.int16)
+
+        # Create recognizer
+        recognizer = KaldiRecognizer(vosk_model, sample_rate)
+
+        # Feed audio into recognizer
+        recognizer.AcceptWaveform(audio_array.tobytes())
+        result = json.loads(recognizer.FinalResult())
+
+        return result.get("text", "").strip() or "[untranscribed audio]"
+    except Exception as e:
+        print(f"[ERROR] Vosk transcription failed: {e}")
+        return "[untranscribed audio]"


### PR DESCRIPTION
Fixed: #17

This PR adds audio mode support to the Mock Interview Agent. Users can now interact with the agent via voice in addition to text. It also introduces speech-to-text transcription using Vosk, so audio messages are converted back from PCM audio into text and stored in transcripts.

- Stored the audio first and transcribed later when saving in interview data
- save_transcript() now normalizes audio transcripts:
  - If in `TEXT` mode → saves transcript as-is.
  - If in `AUDIO` mode → passes PCM bytes to r`un_speech_to_text()` for transcription.
- Added `normalize_transcript()` to run all for converting raw audio to text.
- Utilities
  - Added `backend/tools/speech_to_text.py` with `run_speech_to_text()` wrapper (using Vosk).
  - Updated requirements to include **vosk**.
  - Script added (`scripts/download_vosk_model.sh`) for downloading the Vosk model.

## Notes/Questions
- Vosk setup is added in `README.md` file under `interviewer/` because the model file is too large to upload to GitHub
- Next Step:
  - Test with real microphone audio from frontend.

## Checklist
- [ ] I’ve run all relevant tests with `pytest` and they passed
- [x] Code follows the same **import convention** using absolute paths. (e.g. `from backend.data.database import firestore_db`)
- [ ] I’ve updated or added tests as needed
- [x] I’ve updated `requirements.txt` if I installed new packages
- [x] I’ve added/updated `README.md` if I made any necessary setup/config changes (env vars, API keys, Tool setup like Firebase, complex test instructions, etc.)

## How to Test
<!-- Instructions for reviewers to test the feature -->
No test
